### PR TITLE
Fix pensandoodireito/participacao-sitebase#190

### DIFF
--- a/share-links.php
+++ b/share-links.php
@@ -1,5 +1,11 @@
 <div class="row divider-top">
     <div class="col-xs-12 text-right">
-        <a href="#" class="btn btn-default btn-sm"><i class="fa fa-share-alt"></i> compartilhe</a>
+        <a href="#" onclick="jQuery('#share-box-<?php the_ID(); ?>').slideToggle('fast'); return false;" class="btn btn-default btn-sm"><i class="fa fa-share-alt"></i> compartilhe</a>
+
+        <?php if (function_exists('ssb_share_icons')): ?>
+        <div id="share-box-<?php the_ID(); ?>" style="display: none;">
+            <?php echo ssb_share_icons(); ?>
+        </div>
+        <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
Chamada de função para exibir os ícones de compartilhamento. Depende do plugin social-share-button. A chamada da dependência está sendo feita de forma segura caso o plugin não esteja presente.
